### PR TITLE
feat: add color-scheme meta and default theme

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,11 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="color-scheme" content="light dark" />
   <title>CM2Git</title>
   <link rel="stylesheet" href="cm2git.css" />
   <script src="cm2git.js" defer></script>
 </head>
-<body>
+<body data-theme="light">
   <div id="app"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `color-scheme` meta tag to signal light and dark support
- set default `data-theme` attribute on body

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3410da42883289b9ba7afe9d5438e