### PR TITLE
feat: add accent color variables and interactive styling

### DIFF
--- a/public/cm2git.css
+++ b/public/cm2git.css
@@ -4,6 +4,9 @@
   --color-text: #555;
   --color-border: #ddd;
   --color-card: #fff;
+  --color-accent: #0066ff;
+  --color-accent-hover: #3385ff;
+  --color-accent-active: #0047b3;
 }
 
 [data-theme='dark'] {
@@ -11,6 +14,9 @@
   --color-text: #eee;
   --color-border: #444;
   --color-card: #262626;
+  --color-accent: #ff6600;
+  --color-accent-hover: #ff8533;
+  --color-accent-active: #cc5200;
 }
 
 body {
@@ -31,6 +37,29 @@ body {
   margin-bottom: 0.5rem;
 }
 
+#app > button {
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+#app > button:hover {
+  background: var(--color-accent-hover);
+}
+
+#app > button:active {
+  background: var(--color-accent-active);
+}
+
+#app > select:focus,
+#app > input:focus,
+#app > button:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 #activity {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
@@ -46,19 +75,27 @@ body {
   border: 1px solid var(--color-border);
   border-radius: 4px;
   text-decoration: none;
-  color: inherit;
+  color: var(--color-text);
   background: var(--color-card);
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
-.activity-item:hover {
+.activity-item:hover,
+.activity-item:focus {
   transform: translateY(-2px);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  border-color: var(--color-accent);
+}
+
+.activity-item:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .activity-type {
   font-weight: bold;
   text-transform: uppercase;
+  color: var(--color-accent);
 }
 
 .activity-date {


### PR DESCRIPTION
## Summary
- add vibrant `--color-accent` variables for light and dark themes with hover/active variants
- style buttons, focus states, and activity items to use the accent color
- highlight activity types with the accent for visual emphasis

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b34300ad488328a1e9ea1fc0952028