### PR TITLE
docs: explain accent color variable

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -29,3 +29,25 @@ firebase deploy --only hosting
 ```
 
 Once deployed, the page will be available at `/cm2git/` under the site's domain, matching the local structure.
+
+## Accent color
+
+The stylesheet `cm2git.css` defines `--color-accent` to control the highlight color used for interactive elements such as buttons and headings. Adjust the value under `:root` for the default light theme and override it inside `[data-theme='dark']` for dark mode:
+
+```css
+:root {
+  --color-accent: #0066ff; /* light theme */
+}
+
+[data-theme='dark'] {
+  --color-accent: #ff6600; /* dark theme */
+}
+```
+
+Example of the accent color applied to a button:
+
+```css
+#app > button {
+  background: var(--color-accent);
+}
+```


### PR DESCRIPTION
## Summary
- document purpose of `--color-accent`
- describe how to configure light and dark theme accent colors
- show example of accent color on a button

## Testing
- `npm test` *(fails: enoent, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b343df312883288d356bb04bf22b7b