### PR TITLE
Use purple accent color in dark theme

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -40,7 +40,7 @@ The stylesheet `cm2git.css` defines `--color-accent` to control the highlight co
 }
 
 [data-theme='dark'] {
-  --color-accent: #ff6600; /* dark theme */
+  --color-accent: #7c4dff; /* dark theme */
 }
 ```
 

--- a/public/cm2git.css
+++ b/public/cm2git.css
@@ -14,9 +14,9 @@
   --color-text: #eee;
   --color-border: #444;
   --color-card: #262626;
-  --color-accent: #ff6600;
-  --color-accent-hover: #ff8533;
-  --color-accent-active: #cc5200;
+  --color-accent: #7c4dff;
+  --color-accent-hover: #996aff;
+  --color-accent-active: #5931cc;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Replace orange accent accents with purple (#7c4dff) in dark theme, including hover and active shades
- Update README to document new accent color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b33f3a3e3c8328a2be082efabce273