### PR TITLE
Group commits by PR with expandable activity list

### DIFF
--- a/public/cm2git.css
+++ b/public/cm2git.css
@@ -102,3 +102,41 @@ body {
   font-size: 0.875rem;
   color: var(--color-text);
 }
+
+.pr-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.pr-header {
+  cursor: pointer;
+  position: relative;
+}
+
+.pr-header::after {
+  content: '\25B6';
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+  transition: transform 0.2s;
+}
+
+.pr-group.open .pr-header::after {
+  transform: rotate(90deg);
+}
+
+.pr-details {
+  display: none;
+  margin-left: 1rem;
+  border-left: 2px solid var(--color-border);
+  padding-left: 1rem;
+}
+
+.pr-group.open .pr-details {
+  display: block;
+}
+
+.sub-activity {
+  margin-top: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- nest commit and merge events under their pull request and sort PRs by latest activity
- render PR groups with expandable details and update filters accordingly
- style grouped items with accordion controls and indentation for light and dark themes

## Testing
- `node --check public/cm2git.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b35dd76b5483288e17730d5f06cbbb