### PR TITLE
Add grid view styling and toggle for activity feed

### DIFF
--- a/public/cm2git.css
+++ b/public/cm2git.css
@@ -140,3 +140,40 @@ body {
 .sub-activity {
   margin-top: 0.5rem;
 }
+
+/* Grid view overrides */
+#activity.grid {
+  display: block;
+  grid-template-columns: none;
+  gap: 0;
+  overflow-x: auto;
+}
+
+#activity.grid .activity-item {
+  transition: none;
+}
+
+#activity.grid .activity-item:hover,
+#activity.grid .activity-item:focus {
+  transform: none;
+  box-shadow: none;
+  border-color: var(--color-border);
+}
+
+/* Table layout for activity grid */
+.activity-grid {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.activity-grid th,
+.activity-grid td {
+  padding: 0.5rem;
+  border: 1px solid var(--color-border);
+}
+
+.activity-grid thead th {
+  background: var(--color-accent);
+  color: #fff;
+  text-align: left;
+}

--- a/public/cm2git.js
+++ b/public/cm2git.js
@@ -279,6 +279,7 @@ document.addEventListener('DOMContentLoaded', () => {
   function renderGridActivities(activities, container) {
     container.innerHTML = '';
     const table = document.createElement('table');
+    table.className = 'activity-grid';
 
     const thead = document.createElement('thead');
     const headerRow = document.createElement('tr');
@@ -454,6 +455,7 @@ document.addEventListener('DOMContentLoaded', () => {
       );
       const view = viewSelect.value;
       localStorage.setItem('cm2git-view', view);
+      activityContainer.classList.toggle('grid', view === 'grid');
       if (view === 'grid') {
         renderGridActivities(filtered, activityContainer);
       } else {


### PR DESCRIPTION
## Summary
- style `.activity-grid` tables with borders and themed headers
- add `#activity.grid` modifier to toggle between card and table views
- disable card transitions in grid mode for consistent responsive behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3628af3408328bbedaa1f4bce67df